### PR TITLE
[SIGGRAPH 2020] Fixing cuBLAS issue under Windows

### DIFF
--- a/AI4Animation/SIGGRAPH_2020/DeepLearning/Models/ExpertModel/main.py
+++ b/AI4Animation/SIGGRAPH_2020/DeepLearning/Models/ExpertModel/main.py
@@ -41,7 +41,9 @@ dim_components =            [
 
 def main():
     rng  = np.random.RandomState(23456)
-    sess = tf.Session()
+    config = tf.ConfigProto()
+    config.gpu_options.allow_growth = True
+    sess = tf.Session(config=config)
     network = MainNN(
                 rng,
                 sess,


### PR DESCRIPTION
Training could not be reproduced out of the box under a Windows system. Python environment would point a problem initializing cuBLAS (and all further operations requiring it).
Borrowed a fix described at https://stackoverflow.com/a/52132342 and training was possible as expected.

Do note: I'm not not a TF expert myself, so I can't know if said inclusion would affect overall compatibility.
Similar issues all relate to memory growth. More recent documentation point to alternative solutions as in https://stackoverflow.com/a/60699372

Thanks for the generosity with the code!